### PR TITLE
fix path for android FindMDK.cmake

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -64,7 +64,7 @@ if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/mdk-sdk/lib/cmake/FindMDK.cmake)
     message(FATAL_ERROR "Failed to extract mdk-sdk. You can download manually from ${MDK_SDK_URL} and extract to ${CMAKE_CURRENT_SOURCE_DIR}")
   endif()
 endif()
-include(mdk-sdk/lib/cmake/FindMDK.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/mdk-sdk/lib/cmake/FindMDK.cmake)
 target_link_libraries(${PLUGIN_NAME} PRIVATE mdk
         log)
 

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -65,7 +65,7 @@ if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/mdk-sdk/lib/cmake/FindMDK.cmake)
     message(FATAL_ERROR "Failed to extract mdk-sdk. You can download manually from ${MDK_SDK_URL} and extract to ${CMAKE_CURRENT_SOURCE_DIR}")
   endif()
 endif()
-include(mdk-sdk/lib/cmake/FindMDK.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/mdk-sdk/lib/cmake/FindMDK.cmake)
 target_link_libraries(${PLUGIN_NAME} PRIVATE mdk)
 
 # List of absolute paths to libraries that should be bundled with the plugin.

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -88,7 +88,7 @@ if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/mdk-sdk/lib/cmake/FindMDK.cmake)
     message(FATAL_ERROR "Failed to extract mdk-sdk. You can download manually from ${MDK_SDK_URL} and extract to ${CMAKE_CURRENT_SOURCE_DIR}")
   endif()
 endif()
-include(mdk-sdk/lib/cmake/FindMDK.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/mdk-sdk/lib/cmake/FindMDK.cmake)
 target_link_libraries(${PLUGIN_NAME} PRIVATE mdk)
 
 # List of absolute paths to libraries that should be bundled with the plugin.


### PR DESCRIPTION
fixes this error
```
C/C++: C:\Pub\Cache\hosted\pub.flutter-io.cn\fvp-0.1.0\android\CMakeLists.txt debug|armeabi-v7a : CMake Error at C:\Users\Administrator\AppData\Local\Pub\Cache\hosted\pub.flutter-io.cn\fvp-0.1.0\android\CMakeLists.txt:67 (include):
include could not find load file:

  mdk-sdk/lib/cmake/FindMDK.cmake
  ```