### PR TITLE
fix(darwin): change SPM to dynamically link the framework

### DIFF
--- a/darwin/fvp/Package.swift
+++ b/darwin/fvp/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
         .macOS("10.13"),
     ],
     products: [
-        .library(name: "fvp", targets: ["fvp"]),
+        .library(name: "fvp", type: .dynamic, targets: ["fvp"]),
     ],
     dependencies: [
         .package(name: "FlutterFramework", path: "../FlutterFramework"),
@@ -37,6 +37,7 @@ let package = Package(
                 .unsafeFlags(["-Wno-documentation"]),
             ],
             linkerSettings: [
+                .linkedFramework("Flutter"),
                 .linkedFramework("AVFoundation"),
                 .linkedFramework("CoreVideo"),
                 .linkedFramework("Metal"),

--- a/darwin/fvp/Package.swift
+++ b/darwin/fvp/Package.swift
@@ -37,7 +37,8 @@ let package = Package(
                 .unsafeFlags(["-Wno-documentation"]),
             ],
             linkerSettings: [
-                .linkedFramework("Flutter"),
+                .linkedFramework("Flutter", .when(platforms: [.iOS])),
+                .linkedFramework("FlutterMacOS", .when(platforms: [.macOS])),
                 .linkedFramework("AVFoundation"),
                 .linkedFramework("CoreVideo"),
                 .linkedFramework("Metal"),


### PR DESCRIPTION
With the introduction of SPM the framework gets statically linked resulting in:
```dart
[ERROR:flutter/runtime/dart_vm_initializer.cc(40)] Unhandled Exception: Invalid argument(s): Failed to load dynamic library 'fvp.framework/fvp': dlopen(fvp.framework/fvp, 0x0001): tried: 'fvp.framework/fvp' (no such file),
'/usr/lib/fvp.framework/fvp' (no such file, not in dyld cache), 'fvp.framework/fvp' (no such file).
```

This PR changes this so that it gets dynamically linked and fixes the issue.

Devices tested:
- iOS Simulator
- Physical iPhone (Debug)
- Physical iPhone (Release)
- Physical Mac (Debug)
- Physical Mac (Release) 