### PR TITLE
fix(windows): extract mdk-sdk via realpath to avoid CMake symlink rejection

### DIFF
--- a/cmake/deps.cmake
+++ b/cmake/deps.cmake
@@ -76,9 +76,17 @@ macro(fvp_setup_deps)
       file(MD5 ${MDK_SDK_SAVE} MDK_SDK_MD5_SAVE)
       message("MDK_SDK_MD5_SAVE: ${MDK_SDK_MD5_SAVE}")
     endif()
+    # On Flutter Windows, CMAKE_CURRENT_SOURCE_DIR is reached through the
+    # generated plugin symlink (.../flutter/ephemeral/.plugin_symlinks/fvp).
+    # Newer CMake's `cmake -E tar` extracts with ARCHIVE_EXTRACT_SECURE_SYMLINKS,
+    # which refuses to write entries through a symlinked directory
+    # ("Cannot extract through symlink"). Resolve the real path so extraction
+    # targets a non-symlinked directory. REALPATH (vs file(REAL_PATH)) keeps
+    # this compatible with the cmake_minimum_required(3.17) of this plugin.
+    get_filename_component(MDK_SDK_EXTRACT_DIR "${CMAKE_CURRENT_SOURCE_DIR}" REALPATH)
     execute_process(
       COMMAND ${CMAKE_COMMAND} -E tar "xvf" ${MDK_SDK_SAVE} # "--format=7zip"
-      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+      WORKING_DIRECTORY ${MDK_SDK_EXTRACT_DIR}
       OUTPUT_STRIP_TRAILING_WHITESPACE
       RESULT_VARIABLE EXTRACT_RET
     )

--- a/cmake/deps.cmake
+++ b/cmake/deps.cmake
@@ -85,8 +85,8 @@ macro(fvp_setup_deps)
     # this compatible with the cmake_minimum_required(3.17) of this plugin.
     get_filename_component(MDK_SDK_EXTRACT_DIR "${CMAKE_CURRENT_SOURCE_DIR}" REALPATH)
     execute_process(
-      COMMAND ${CMAKE_COMMAND} -E tar "xvf" ${MDK_SDK_SAVE} # "--format=7zip"
-      WORKING_DIRECTORY ${MDK_SDK_EXTRACT_DIR}
+      COMMAND ${CMAKE_COMMAND} -E tar "xvf" "${MDK_SDK_SAVE}" # "--format=7zip"
+      WORKING_DIRECTORY "${MDK_SDK_EXTRACT_DIR}"
       OUTPUT_STRIP_TRAILING_WHITESPACE
       RESULT_VARIABLE EXTRACT_RET
     )


### PR DESCRIPTION
Fixes #366.

### Problem
`flutter build windows --release` fails in `fvp_setup_deps` while extracting `mdk-sdk-windows-x64.7z`:

```
CMake Error: Problem with archive_write_header(): Cannot extract through symlink
  ...\windows\flutter\ephemeral\.plugin_symlinks\fvp
Failed to extract mdk-sdk.
```

On Flutter Windows, `CMAKE_CURRENT_SOURCE_DIR` is reached through the generated plugin symlink (`.plugin_symlinks/fvp`). Newer CMake's `cmake -E tar` extracts with `ARCHIVE_EXTRACT_SECURE_SYMLINKS` and refuses to write entries through a symlinked directory. The download itself is fine (verified: byte-identical 7z, valid magic) — only the extraction step is rejected. This started when CI runner images bumped their bundled CMake (≥ 3.31), with no project change.

### Fix
Resolve `CMAKE_CURRENT_SOURCE_DIR` to its real (non-symlinked) path and extract there:

```cmake
get_filename_component(MDK_SDK_EXTRACT_DIR "${CMAKE_CURRENT_SOURCE_DIR}" REALPATH)
execute_process(
  COMMAND ${CMAKE_COMMAND} -E tar "xvf" ${MDK_SDK_SAVE}
  WORKING_DIRECTORY ${MDK_SDK_EXTRACT_DIR}
  ...)
```

`get_filename_component(... REALPATH)` is used instead of `file(REAL_PATH)` to stay compatible with the plugin's `cmake_minimum_required(VERSION 3.17)`. On platforms where the path is not a symlink, REALPATH is a no-op (resolves to the same directory), so behavior is unchanged elsewhere. The subsequent `include(${CMAKE_CURRENT_SOURCE_DIR}/mdk-sdk/.../FindMDK.cmake)` still resolves through the symlink (reading through a symlink is fine).

### Verification
Built the `example/` app on `windows-latest` (same runner image that fails today, same plugin-symlink scenario, same mdk-sdk download). It now extracts and builds successfully:

```
Downloading mdk-sdk from https://sourceforge.net/projects/mdk-sdk/files/nightly/mdk-sdk-windows-x64.7z
MDK_SDK_MD5_SAVE: 1e59ba0aed23f2723642c69fec07888e
Building Windows application...                    79.3s
√ Built build\windows\x64\runner\Release\fvp_example.exe
```

(no `Cannot extract through symlink`.)
