### PR TITLE
fix(darwin): ship PrivacyInfo.xcprivacy as a real file for SwiftPM

### DIFF
--- a/darwin/fvp/Resources/PrivacyInfo.xcprivacy
+++ b/darwin/fvp/Resources/PrivacyInfo.xcprivacy
@@ -1,1 +1,14 @@
-../../PrivacyInfo.xcprivacy
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>


### PR DESCRIPTION
Fixes #372.

`darwin/fvp/Resources/PrivacyInfo.xcprivacy` is a symlink to
`../../PrivacyInfo.xcprivacy`, which points **outside** the SwiftPM package root
(`darwin/fvp`). The target declares it as a resource via
`.process("Resources/PrivacyInfo.xcprivacy")`.

When a host app builds with Swift Package Manager enabled, Flutter symlinks each
plugin package into `<app>/macos/Flutter/ephemeral/Packages/.packages/<pkg>`.
Xcode then resolves the escaping resource symlink relative to that symlinked
location and looks for the file at `.packages/PrivacyInfo.xcprivacy`
(= `.packages/<pkg>/../PrivacyInfo.xcprivacy`), which does not exist:

```
error: <app>/macos/Flutter/ephemeral/Packages/.packages/PrivacyInfo.xcprivacy: No such file or directory (in target 'fvp_fvp' from project 'fvp')
** BUILD FAILED **
```

so `flutter build macos` / `ios` fails for any app on SwiftPM. (The
`Sources/fvp/*` symlinks compile fine — Xcode follows symlinks for compile
inputs; only the `.process` resource-copy phase breaks on the escaping link.)

### Fix
Ship the manifest as a real file inside the package, matching the pattern
first-party plugins use (e.g. `connectivity_plus` keeps a real
`PrivacyInfo.xcprivacy` under `Sources/<target>/`). The CocoaPods path is
unchanged — the podspec still references `darwin/PrivacyInfo.xcprivacy`.

### Verified
`flutter build macos` (Flutter 3.44.2, Xcode 26.5, SwiftPM enabled) now
completes and packages successfully; CocoaPods builds remain unaffected.