### PR TITLE
android: implement VideoViewType.platformView with SurfaceView output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,11 +114,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['3.10.x', 'any']
+        version: ['any']
         channel: ['stable', 'beta']
-        exclude:
-          - version: '3.10.x'
-            channel: 'beta'
     steps:
     - uses: actions/checkout@v6
       with:

--- a/android/fvp_plugin.cpp
+++ b/android/fvp_plugin.cpp
@@ -79,6 +79,11 @@ Java_com_mediadevkit_fvp_FvpPlugin_nativeSetSurface(JNIEnv *env, jobject thiz, j
     if (tunnel) { // TODO: tunel via ffi + global var
         player->surface = env->NewGlobalRef(surface);
         player->setProperty("video.decoder", "surface=" + std::to_string((intptr_t)player->surface));
+        // Platform-view surfaces (FvpVideoView) arrive after prepare(), when
+        // the video decoder has already opened without a tunnel surface.
+        // Re-set the decoder list to force a decoder re-open so the surface
+        // property takes effect. Tunneled output requires MediaCodec.
+        player->setDecoders(mdk::MediaType::Video, {"AMediaCodec"});
     } else {
         player->updateNativeSurface(surface, w, h);
         player->vo_opaque = surface;

--- a/android/fvp_plugin.cpp
+++ b/android/fvp_plugin.cpp
@@ -28,6 +28,7 @@ public:
     int height = 0;
     jobject surface = nullptr;
     void* vo_opaque = nullptr; // can change by TextureRegistry.SurfaceProducer.Callback
+    bool directSurface = false; // decoder renders into the surface, no GL renderer
 private:
 };
 
@@ -58,15 +59,30 @@ void JNI_OnUnload(JavaVM *vm, void *reserved) {
 extern "C"
 JNIEXPORT void JNICALL
 Java_com_mediadevkit_fvp_FvpPlugin_nativeSetSurface(JNIEnv *env, jobject thiz, jlong player_handle,
-                                                    jlong tex_id, jobject surface, jint w, jint h, jboolean tunnel) {
+                                                    jlong tex_id, jobject surface, jint w, jint h, jboolean tunnel,
+                                                    jboolean direct) {
     if (!player_handle || !surface) {
         if (auto it = players.find(tex_id); it != players.end()) {
             auto& player = it->second;
             auto s = player->surface;
+            if (player->directSurface) {
+                // The codec renders into the surface that is about to be
+                // destroyed. Detach it BEFORE the surface dies: a MediaCodec
+                // left bound to a dead surface wedges (dequeue -10000, "can
+                // not return buffer to native window") and the stream is
+                // marked decode-error, so the next surface never shows a
+                // frame. An empty decoder list releases the codec without
+                // opening a replacement — re-opening one here would run a
+                // full codec create+configure+start and re-prime the pipeline
+                // synchronously, on the UI thread inside surfaceDestroyed
+                // (~600ms with a deep buffer). The re-attach below re-opens
+                // with the new surface.
+                player->setDecoders(mdk::MediaType::Video, {});
+            }
             player->updateNativeSurface(nullptr);
             players.erase(it);
             if (s) {
-                env->DeleteGlobalRef(surface);
+                env->DeleteGlobalRef(s);
             }
         } else {
             clog << "player not found(already removed?) for textureId " + std::to_string(tex_id) + " surface " + std::to_string((intptr_t)surface) << endl;
@@ -84,11 +100,45 @@ Java_com_mediadevkit_fvp_FvpPlugin_nativeSetSurface(JNIEnv *env, jobject thiz, j
         // Re-set the decoder list to force a decoder re-open so the surface
         // property takes effect. Tunneled output requires MediaCodec.
         player->setDecoders(mdk::MediaType::Video, {"AMediaCodec"});
+    } else if (direct) {
+        // Hand the surface to MediaCodec itself: decoded frames go straight
+        // into the SurfaceView's buffer queue, with no GL renderer, no
+        // EGLConfig and no GPU copy in between. image=0 disables the
+        // AImageReader (frame readback) path; dv=1 is required for Dolby
+        // Vision profile 5 to a SurfaceView on older SDKs. The surface arrives
+        // after prepare(), so setDecoders forces a decoder re-open with it
+        // attached.
+        player->surface = env->NewGlobalRef(surface);
+        player->directSurface = true;
+        player->setDecoders(mdk::MediaType::Video,
+            {"AMediaCodec:dv=1:image=0:surface=" + std::to_string((intptr_t)player->surface)});
     } else {
-        player->updateNativeSurface(surface, w, h);
-        player->vo_opaque = surface;
+        player->surface = env->NewGlobalRef(surface);
+        player->updateNativeSurface(player->surface, w, h);
+        player->vo_opaque = player->surface;
     }
+    player->width = w;
+    player->height = h;
     players[tex_id] = player;
+}
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_com_mediadevkit_fvp_FvpPlugin_nativeSetSurfaceSize(JNIEnv *env, jobject thiz, jlong tex_id,
+                                                        jint w, jint h) {
+    auto it = players.find(tex_id);
+    if (it == players.end()) {
+        return;
+    }
+    auto& player = it->second;
+    player->width = w;
+    player->height = h;
+    // The decoder owns the buffer geometry in direct mode — the compositor
+    // scales its layer to the view, so a resize needs nothing here. The GL
+    // renderer draws at the surface size and does need it.
+    if (!player->directSurface && player->surface) {
+        player->updateNativeSurface(player->surface, w, h);
+    }
 }
 
 extern "C"

--- a/android/fvp_plugin.cpp
+++ b/android/fvp_plugin.cpp
@@ -65,17 +65,12 @@ Java_com_mediadevkit_fvp_FvpPlugin_nativeSetSurface(JNIEnv *env, jobject thiz, j
             auto& player = it->second;
             auto s = player->surface;
             if (player->directSurface) {
-                // The codec renders into the surface that is about to be
-                // destroyed. Detach it BEFORE the surface dies: a MediaCodec
-                // left bound to a dead surface wedges (dequeue -10000, "can
-                // not return buffer to native window") and the stream is
-                // marked decode-error, so the next surface never shows a
-                // frame. An empty decoder list releases the codec without
-                // opening a replacement — re-opening one here would run a
-                // full codec create+configure+start and re-prime the pipeline
-                // synchronously, on the UI thread inside surfaceDestroyed
-                // (~600ms with a deep buffer). The re-attach below re-opens
-                // with the new surface.
+                // Release the codec BEFORE the surface dies, or it wedges
+                // (dequeue -10000) and the stream is marked decode-error, so
+                // the next surface never shows a frame. Empty list, not a
+                // surface-less re-open: that costs ~600ms of codec restart
+                // and pipeline re-prime, here on the UI thread inside
+                // surfaceDestroyed.
                 player->setDecoders(mdk::MediaType::Video, {});
             }
             player->updateNativeSurface(nullptr);
@@ -92,16 +87,11 @@ Java_com_mediadevkit_fvp_FvpPlugin_nativeSetSurface(JNIEnv *env, jobject thiz, j
     auto player = make_shared<TexturePlayer>(player_handle);
     clog << __func__ << endl;
     if (tunnel) {
-        // Decode straight into the surface: MediaCodec writes into the
-        // SurfaceView's (or SurfaceTexture's) buffer queue itself, with no GL
-        // renderer, no EGLConfig and no GPU copy in between. image=0 disables
-        // the AImageReader (frame readback) path; dv=1 is required for Dolby
-        // Vision profile 5 on SDKs where it is not the default.
-        //
-        // The surface only exists after prepare(), by which point the decoder
-        // has already opened without one, so setDecoders forces a re-open with
-        // it attached — setting the property alone never took effect, which is
-        // why this option did nothing before.
+        // MediaCodec writes into the surface's buffer queue itself: no GL
+        // renderer, no EGLConfig, no GPU copy. image=0 drops the AImageReader
+        // readback path; dv=1 is needed for Dolby Vision profile 5 on older
+        // SDKs. The surface only exists after prepare(), so setDecoders is
+        // what forces the re-open that makes it take effect.
         player->surface = env->NewGlobalRef(surface);
         player->directSurface = true;
         player->setDecoders(mdk::MediaType::Video,
@@ -127,9 +117,8 @@ Java_com_mediadevkit_fvp_FvpPlugin_nativeSetSurfaceSize(JNIEnv *env, jobject thi
     auto& player = it->second;
     player->width = w;
     player->height = h;
-    // The decoder owns the buffer geometry in direct mode — the compositor
-    // scales its layer to the view, so a resize needs nothing here. The GL
-    // renderer draws at the surface size and does need it.
+    // Only the GL renderer draws at the surface size; with tunnel the decoder
+    // owns the geometry and the compositor scales its layer.
     if (!player->directSurface && player->surface) {
         player->updateNativeSurface(player->surface, w, h);
     }

--- a/android/fvp_plugin.cpp
+++ b/android/fvp_plugin.cpp
@@ -59,8 +59,7 @@ void JNI_OnUnload(JavaVM *vm, void *reserved) {
 extern "C"
 JNIEXPORT void JNICALL
 Java_com_mediadevkit_fvp_FvpPlugin_nativeSetSurface(JNIEnv *env, jobject thiz, jlong player_handle,
-                                                    jlong tex_id, jobject surface, jint w, jint h, jboolean tunnel,
-                                                    jboolean direct) {
+                                                    jlong tex_id, jobject surface, jint w, jint h, jboolean tunnel) {
     if (!player_handle || !surface) {
         if (auto it = players.find(tex_id); it != players.end()) {
             auto& player = it->second;
@@ -92,22 +91,17 @@ Java_com_mediadevkit_fvp_FvpPlugin_nativeSetSurface(JNIEnv *env, jobject thiz, j
     assert(surface && "null surface");
     auto player = make_shared<TexturePlayer>(player_handle);
     clog << __func__ << endl;
-    if (tunnel) { // TODO: tunel via ffi + global var
-        player->surface = env->NewGlobalRef(surface);
-        player->setProperty("video.decoder", "surface=" + std::to_string((intptr_t)player->surface));
-        // Platform-view surfaces (FvpVideoView) arrive after prepare(), when
-        // the video decoder has already opened without a tunnel surface.
-        // Re-set the decoder list to force a decoder re-open so the surface
-        // property takes effect. Tunneled output requires MediaCodec.
-        player->setDecoders(mdk::MediaType::Video, {"AMediaCodec"});
-    } else if (direct) {
-        // Hand the surface to MediaCodec itself: decoded frames go straight
-        // into the SurfaceView's buffer queue, with no GL renderer, no
-        // EGLConfig and no GPU copy in between. image=0 disables the
-        // AImageReader (frame readback) path; dv=1 is required for Dolby
-        // Vision profile 5 to a SurfaceView on older SDKs. The surface arrives
-        // after prepare(), so setDecoders forces a decoder re-open with it
-        // attached.
+    if (tunnel) {
+        // Decode straight into the surface: MediaCodec writes into the
+        // SurfaceView's (or SurfaceTexture's) buffer queue itself, with no GL
+        // renderer, no EGLConfig and no GPU copy in between. image=0 disables
+        // the AImageReader (frame readback) path; dv=1 is required for Dolby
+        // Vision profile 5 on SDKs where it is not the default.
+        //
+        // The surface only exists after prepare(), by which point the decoder
+        // has already opened without one, so setDecoders forces a re-open with
+        // it attached — setting the property alone never took effect, which is
+        // why this option did nothing before.
         player->surface = env->NewGlobalRef(surface);
         player->directSurface = true;
         player->setDecoders(mdk::MediaType::Video,

--- a/android/src/main/java/com/mediadevkit/fvp/FvpPlugin.java
+++ b/android/src/main/java/com/mediadevkit/fvp/FvpPlugin.java
@@ -58,6 +58,9 @@ public class FvpPlugin implements FlutterPlugin, MethodCallHandler {
     texRegistry = flutterPluginBinding.getTextureRegistry();
     textures = new HashMap<>();
     surfaces = new HashMap<>();
+    // SurfaceView output for VideoViewType.platformView (full display
+    // resolution on TVs with an upscaled UI layer; tunneled playback).
+    flutterPluginBinding.getPlatformViewRegistry().registerViewFactory("fvp/video-view", new FvpVideoViewFactory());
   }
 
   @Override
@@ -148,9 +151,9 @@ public class FvpPlugin implements FlutterPlugin, MethodCallHandler {
 
   /*!
     \param playerHandle null to destroy
-    \param texId
+    \param texId a TextureRegistry id, or a negative synthetic id for platform views (FvpVideoView)
    */
-  private native void nativeSetSurface(long playerHandle, long texId, Surface surface, int w, int h, boolean tunnel);
+  static native void nativeSetSurface(long playerHandle, long texId, Surface surface, int w, int h, boolean tunnel);
 
   static {
     try {

--- a/android/src/main/java/com/mediadevkit/fvp/FvpPlugin.java
+++ b/android/src/main/java/com/mediadevkit/fvp/FvpPlugin.java
@@ -86,7 +86,7 @@ public class FvpPlugin implements FlutterPlugin, MethodCallHandler {
         te = ste;
       }
       final long texId = te.id();
-      nativeSetSurface(handle, texId, surface, width, height, tunnel, false);
+      nativeSetSurface(handle, texId, surface, width, height, tunnel);
       textures.put(texId, te);
       surfaces.put(texId, surface);
       result.success(texId);
@@ -101,14 +101,14 @@ public class FvpPlugin implements FlutterPlugin, MethodCallHandler {
                     final Surface newSurface = sp.getSurface();
                     surfaces.put(texId, newSurface);
                     // will do nothing if same surface
-                    nativeSetSurface(handle, texId, newSurface, width, height, tunnel, false);
+                    nativeSetSurface(handle, texId, newSurface, width, height, tunnel);
                   }
 
                   @Override
                   public void onSurfaceCleanup() {
                     Log.d("FvpPlugin", "SurfaceProducer.onSurfaceCleanup for textureId " + texId);
                     textures.remove(texId);
-                    nativeSetSurface(handle, texId, null, 0, 0, tunnel, false);
+                    nativeSetSurface(handle, texId, null, 0, 0, tunnel);
                   }
                 }
         );
@@ -117,7 +117,7 @@ public class FvpPlugin implements FlutterPlugin, MethodCallHandler {
     } else if (call.method.equals("ReleaseRT")) {
       final int texId = call.argument("texture"); // 32bit int, 0, 1, 2 .... but SurfaceTexture.id() is long
       final long texId64 = texId; // MUST cast texId to long, otherwise remove() error
-      nativeSetSurface(0, texId, null, -1, -1, false, false);
+      nativeSetSurface(0, texId, null, -1, -1, false);
       TextureEntry te = textures.get(texId64);
       if (te == null) {
         Log.w("FvpPlugin", "onMethodCall: ReleaseRT texId not found: " + texId);
@@ -144,7 +144,7 @@ public class FvpPlugin implements FlutterPlugin, MethodCallHandler {
   public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
     channel.setMethodCallHandler(null);
     Log.i("FvpPlugin", "onDetachedFromEngine: ");
-    for (long texId : textures.keySet()) { nativeSetSurface(0, texId, null, -1, -1, false, false);}
+    for (long texId : textures.keySet()) { nativeSetSurface(0, texId, null, -1, -1, false);}
     surfaces = null;
     textures = null;
   }
@@ -153,11 +153,11 @@ public class FvpPlugin implements FlutterPlugin, MethodCallHandler {
     \param playerHandle null to destroy
     \param texId a TextureRegistry id, or a negative synthetic id for platform views (FvpVideoView)
    */
-  static native void nativeSetSurface(long playerHandle, long texId, Surface surface, int w, int h, boolean tunnel, boolean direct);
+  static native void nativeSetSurface(long playerHandle, long texId, Surface surface, int w, int h, boolean tunnel);
 
   /*!
     Surface size change (SurfaceHolder.Callback.surfaceChanged). Only the GL
-    render path needs it; in direct mode the decoder owns the buffer geometry.
+    render path needs it; with "tunnel" the decoder owns the buffer geometry.
    */
   static native void nativeSetSurfaceSize(long texId, int w, int h);
 

--- a/android/src/main/java/com/mediadevkit/fvp/FvpPlugin.java
+++ b/android/src/main/java/com/mediadevkit/fvp/FvpPlugin.java
@@ -86,7 +86,7 @@ public class FvpPlugin implements FlutterPlugin, MethodCallHandler {
         te = ste;
       }
       final long texId = te.id();
-      nativeSetSurface(handle, texId, surface, width, height, tunnel);
+      nativeSetSurface(handle, texId, surface, width, height, tunnel, false);
       textures.put(texId, te);
       surfaces.put(texId, surface);
       result.success(texId);
@@ -101,14 +101,14 @@ public class FvpPlugin implements FlutterPlugin, MethodCallHandler {
                     final Surface newSurface = sp.getSurface();
                     surfaces.put(texId, newSurface);
                     // will do nothing if same surface
-                    nativeSetSurface(handle, texId, newSurface, width, height, tunnel);
+                    nativeSetSurface(handle, texId, newSurface, width, height, tunnel, false);
                   }
 
                   @Override
                   public void onSurfaceCleanup() {
                     Log.d("FvpPlugin", "SurfaceProducer.onSurfaceCleanup for textureId " + texId);
                     textures.remove(texId);
-                    nativeSetSurface(handle, texId, null, 0, 0, tunnel);
+                    nativeSetSurface(handle, texId, null, 0, 0, tunnel, false);
                   }
                 }
         );
@@ -117,7 +117,7 @@ public class FvpPlugin implements FlutterPlugin, MethodCallHandler {
     } else if (call.method.equals("ReleaseRT")) {
       final int texId = call.argument("texture"); // 32bit int, 0, 1, 2 .... but SurfaceTexture.id() is long
       final long texId64 = texId; // MUST cast texId to long, otherwise remove() error
-      nativeSetSurface(0, texId, null, -1, -1, false);
+      nativeSetSurface(0, texId, null, -1, -1, false, false);
       TextureEntry te = textures.get(texId64);
       if (te == null) {
         Log.w("FvpPlugin", "onMethodCall: ReleaseRT texId not found: " + texId);
@@ -144,7 +144,7 @@ public class FvpPlugin implements FlutterPlugin, MethodCallHandler {
   public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
     channel.setMethodCallHandler(null);
     Log.i("FvpPlugin", "onDetachedFromEngine: ");
-    for (long texId : textures.keySet()) { nativeSetSurface(0, texId, null, -1, -1, false);}
+    for (long texId : textures.keySet()) { nativeSetSurface(0, texId, null, -1, -1, false, false);}
     surfaces = null;
     textures = null;
   }
@@ -153,7 +153,13 @@ public class FvpPlugin implements FlutterPlugin, MethodCallHandler {
     \param playerHandle null to destroy
     \param texId a TextureRegistry id, or a negative synthetic id for platform views (FvpVideoView)
    */
-  static native void nativeSetSurface(long playerHandle, long texId, Surface surface, int w, int h, boolean tunnel);
+  static native void nativeSetSurface(long playerHandle, long texId, Surface surface, int w, int h, boolean tunnel, boolean direct);
+
+  /*!
+    Surface size change (SurfaceHolder.Callback.surfaceChanged). Only the GL
+    render path needs it; in direct mode the decoder owns the buffer geometry.
+   */
+  static native void nativeSetSurfaceSize(long texId, int w, int h);
 
   static {
     try {

--- a/android/src/main/java/com/mediadevkit/fvp/FvpVideoView.java
+++ b/android/src/main/java/com/mediadevkit/fvp/FvpVideoView.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026 WangBin <wbsecg1 at gmail.com>
+ */
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+package com.mediadevkit.fvp;
+
+import android.content.Context;
+import android.util.Log;
+import android.view.SurfaceHolder;
+import android.view.SurfaceView;
+import android.view.View;
+
+import java.util.Map;
+
+import io.flutter.plugin.platform.PlatformView;
+
+/**
+ * SurfaceView video output, used when the app requests
+ * VideoViewType.platformView.
+ *
+ * Unlike the Texture path (ImageReader buffers composited inside the app
+ * window), a SurfaceView gets its own display layer. On Android TVs that run
+ * the UI layer below the panel resolution (e.g. 1080p UI on a 4K panel) this
+ * is the only way to present video at full display resolution — see
+ * https://developer.android.com/media/media3/ui/surface. It is also the only
+ * surface type that can display tunneled (sideband) playback.
+ *
+ * The surface buffers are fixed to the video resolution, not the view size,
+ * so a 4K video scans out at 4K even when the window is 1080p.
+ */
+public class FvpVideoView implements PlatformView, SurfaceHolder.Callback {
+    private final SurfaceView surfaceView;
+    private final long playerHandle;
+    // Key into the native players map (fvp_plugin.cpp). Texture ids from
+    // TextureRegistry count up from 0, platform view ids do too — offset into
+    // negative space so the two id families can never collide.
+    private final long surfaceId;
+    private final int videoWidth;
+    private final int videoHeight;
+    private final boolean tunnel;
+    private boolean released = false;
+
+    FvpVideoView(Context context, int viewId, Map<String, Object> params) {
+        playerHandle = ((Number) params.get("player")).longValue();
+        videoWidth = ((Number) params.get("width")).intValue();
+        videoHeight = ((Number) params.get("height")).intValue();
+        tunnel = Boolean.TRUE.equals(params.get("tunnel"));
+        surfaceId = -1000L - viewId;
+        surfaceView = new SurfaceView(context);
+        if (videoWidth > 0 && videoHeight > 0) {
+            // Buffers at video resolution; the compositor scales the layer to
+            // the view's screen rect at scanout, preserving full detail.
+            surfaceView.getHolder().setFixedSize(videoWidth, videoHeight);
+        }
+        surfaceView.getHolder().addCallback(this);
+    }
+
+    @Override
+    public View getView() {
+        return surfaceView;
+    }
+
+    @Override
+    public void surfaceCreated(SurfaceHolder holder) {
+        Log.i("FvpPlugin", "FvpVideoView surfaceCreated, video " + videoWidth + "x" + videoHeight + ", tunnel " + tunnel);
+        FvpPlugin.nativeSetSurface(playerHandle, surfaceId, holder.getSurface(), videoWidth, videoHeight, tunnel);
+        released = false;
+    }
+
+    @Override
+    public void surfaceChanged(SurfaceHolder holder, int format, int width, int height) {
+        // Buffer size is fixed; nothing to do. Logged for diagnostics.
+        Log.i("FvpPlugin", "FvpVideoView surfaceChanged " + width + "x" + height + " format " + format);
+    }
+
+    @Override
+    public void surfaceDestroyed(SurfaceHolder holder) {
+        release();
+    }
+
+    @Override
+    public void dispose() {
+        surfaceView.getHolder().removeCallback(this);
+        release();
+    }
+
+    private void release() {
+        if (released) {
+            return;
+        }
+        released = true;
+        FvpPlugin.nativeSetSurface(0, surfaceId, null, -1, -1, tunnel);
+    }
+}

--- a/android/src/main/java/com/mediadevkit/fvp/FvpVideoView.java
+++ b/android/src/main/java/com/mediadevkit/fvp/FvpVideoView.java
@@ -39,13 +39,20 @@ public class FvpVideoView implements PlatformView, SurfaceHolder.Callback {
     private final int videoWidth;
     private final int videoHeight;
     private final boolean tunnel;
+    // MediaCodec renders straight into this view's surface (no GL renderer).
+    private final boolean direct;
     private boolean released = false;
+    // Last size handed to the native side, so a surfaceChanged reporting the
+    // size already set (the usual case with setFixedSize) costs nothing.
+    private int surfaceWidth;
+    private int surfaceHeight;
 
     FvpVideoView(Context context, int viewId, Map<String, Object> params) {
         playerHandle = ((Number) params.get("player")).longValue();
         videoWidth = ((Number) params.get("width")).intValue();
         videoHeight = ((Number) params.get("height")).intValue();
         tunnel = Boolean.TRUE.equals(params.get("tunnel"));
+        direct = Boolean.TRUE.equals(params.get("direct"));
         surfaceId = -1000L - viewId;
         surfaceView = new SurfaceView(context);
         if (videoWidth > 0 && videoHeight > 0) {
@@ -63,15 +70,25 @@ public class FvpVideoView implements PlatformView, SurfaceHolder.Callback {
 
     @Override
     public void surfaceCreated(SurfaceHolder holder) {
-        Log.i("FvpPlugin", "FvpVideoView surfaceCreated, video " + videoWidth + "x" + videoHeight + ", tunnel " + tunnel);
-        FvpPlugin.nativeSetSurface(playerHandle, surfaceId, holder.getSurface(), videoWidth, videoHeight, tunnel);
+        Log.i("FvpPlugin", "FvpVideoView surfaceCreated, video " + videoWidth + "x" + videoHeight + ", tunnel " + tunnel + ", direct " + direct);
+        FvpPlugin.nativeSetSurface(playerHandle, surfaceId, holder.getSurface(), videoWidth, videoHeight, tunnel, direct);
+        surfaceWidth = videoWidth;
+        surfaceHeight = videoHeight;
         released = false;
     }
 
     @Override
     public void surfaceChanged(SurfaceHolder holder, int format, int width, int height) {
-        // Buffer size is fixed; nothing to do. Logged for diagnostics.
         Log.i("FvpPlugin", "FvpVideoView surfaceChanged " + width + "x" + height + " format " + format);
+        if (released || (width == surfaceWidth && height == surfaceHeight)) {
+            return;
+        }
+        surfaceWidth = width;
+        surfaceHeight = height;
+        // With setFixedSize (video size known) this is the video resolution and
+        // never changes, so the check above skips it. Without it the surface
+        // follows the view, and the GL renderer needs the new size.
+        FvpPlugin.nativeSetSurfaceSize(surfaceId, width, height);
     }
 
     @Override
@@ -90,6 +107,6 @@ public class FvpVideoView implements PlatformView, SurfaceHolder.Callback {
             return;
         }
         released = true;
-        FvpPlugin.nativeSetSurface(0, surfaceId, null, -1, -1, tunnel);
+        FvpPlugin.nativeSetSurface(0, surfaceId, null, -1, -1, tunnel, direct);
     }
 }

--- a/android/src/main/java/com/mediadevkit/fvp/FvpVideoView.java
+++ b/android/src/main/java/com/mediadevkit/fvp/FvpVideoView.java
@@ -40,8 +40,7 @@ public class FvpVideoView implements PlatformView, SurfaceHolder.Callback {
     private final int videoHeight;
     private final boolean tunnel;
     private boolean released = false;
-    // Last size handed to the native side, so a surfaceChanged reporting the
-    // size already set (the usual case with setFixedSize) costs nothing.
+    // Last size sent natively; setFixedSize makes most callbacks a no-op.
     private int surfaceWidth;
     private int surfaceHeight;
 
@@ -82,9 +81,7 @@ public class FvpVideoView implements PlatformView, SurfaceHolder.Callback {
         }
         surfaceWidth = width;
         surfaceHeight = height;
-        // With setFixedSize (video size known) this is the video resolution and
-        // never changes, so the check above skips it. Without it the surface
-        // follows the view, and the GL renderer needs the new size.
+        // Only reached without setFixedSize, where the GL renderer needs it.
         FvpPlugin.nativeSetSurfaceSize(surfaceId, width, height);
     }
 

--- a/android/src/main/java/com/mediadevkit/fvp/FvpVideoView.java
+++ b/android/src/main/java/com/mediadevkit/fvp/FvpVideoView.java
@@ -39,8 +39,6 @@ public class FvpVideoView implements PlatformView, SurfaceHolder.Callback {
     private final int videoWidth;
     private final int videoHeight;
     private final boolean tunnel;
-    // MediaCodec renders straight into this view's surface (no GL renderer).
-    private final boolean direct;
     private boolean released = false;
     // Last size handed to the native side, so a surfaceChanged reporting the
     // size already set (the usual case with setFixedSize) costs nothing.
@@ -52,7 +50,6 @@ public class FvpVideoView implements PlatformView, SurfaceHolder.Callback {
         videoWidth = ((Number) params.get("width")).intValue();
         videoHeight = ((Number) params.get("height")).intValue();
         tunnel = Boolean.TRUE.equals(params.get("tunnel"));
-        direct = Boolean.TRUE.equals(params.get("direct"));
         surfaceId = -1000L - viewId;
         surfaceView = new SurfaceView(context);
         if (videoWidth > 0 && videoHeight > 0) {
@@ -70,8 +67,8 @@ public class FvpVideoView implements PlatformView, SurfaceHolder.Callback {
 
     @Override
     public void surfaceCreated(SurfaceHolder holder) {
-        Log.i("FvpPlugin", "FvpVideoView surfaceCreated, video " + videoWidth + "x" + videoHeight + ", tunnel " + tunnel + ", direct " + direct);
-        FvpPlugin.nativeSetSurface(playerHandle, surfaceId, holder.getSurface(), videoWidth, videoHeight, tunnel, direct);
+        Log.i("FvpPlugin", "FvpVideoView surfaceCreated, video " + videoWidth + "x" + videoHeight + ", tunnel " + tunnel);
+        FvpPlugin.nativeSetSurface(playerHandle, surfaceId, holder.getSurface(), videoWidth, videoHeight, tunnel);
         surfaceWidth = videoWidth;
         surfaceHeight = videoHeight;
         released = false;
@@ -107,6 +104,6 @@ public class FvpVideoView implements PlatformView, SurfaceHolder.Callback {
             return;
         }
         released = true;
-        FvpPlugin.nativeSetSurface(0, surfaceId, null, -1, -1, tunnel, direct);
+        FvpPlugin.nativeSetSurface(0, surfaceId, null, -1, -1, tunnel);
     }
 }

--- a/android/src/main/java/com/mediadevkit/fvp/FvpVideoViewFactory.java
+++ b/android/src/main/java/com/mediadevkit/fvp/FvpVideoViewFactory.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 WangBin <wbsecg1 at gmail.com>
+ */
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+package com.mediadevkit.fvp;
+
+import android.content.Context;
+
+import java.util.Map;
+
+import io.flutter.plugin.common.StandardMessageCodec;
+import io.flutter.plugin.platform.PlatformView;
+import io.flutter.plugin.platform.PlatformViewFactory;
+
+/** Creates {@link FvpVideoView}s for the "fvp/video-view" platform view type. */
+public class FvpVideoViewFactory extends PlatformViewFactory {
+    FvpVideoViewFactory() {
+        super(StandardMessageCodec.INSTANCE);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public PlatformView create(Context context, int viewId, Object args) {
+        return new FvpVideoView(context, viewId, (Map<String, Object>) args);
+    }
+}

--- a/lib/fvp.dart
+++ b/lib/fvp.dart
@@ -27,9 +27,7 @@ export 'src/controller.dart';
 ///
 /// "global": backend global options of type [Map<String, Object>]. See https://github.com/wang-bin/mdk-sdk/wiki/Global-Options
 ///
-/// "tunnel": android only, default is false. AMediacodec/MediaCodec decoder output to a SurfaceTexture surface directly without OpenGL. Maybe more efficient, but some features are not supported, e.g. HDR tone mapping, less codecs.
-///
-/// "directSurface": android only, default is false, requires VideoViewType.platformView. MediaCodec renders into the SurfaceView's surface itself: no GL renderer, no EGLConfig, no GPU copy, and the video scans out at its native resolution ("maxWidth"/"maxHeight" are not applied). This is what lets a 4K video present at full panel resolution on TVs whose UI layer runs at 1080p. Same trade-offs as "tunnel": no HDR tone mapping and no frame readback (snapshot).
+/// "tunnel": android only, default is false. AMediacodec/MediaCodec decoder output to the surface directly (a SurfaceTexture, or a SurfaceView via VideoViewType.platformView) without OpenGL: no GL renderer, no EGLConfig, no GPU copy, and the video scans out at its native resolution, so "maxWidth"/"maxHeight" are not applied. This is what lets a 4K video present at full panel resolution on TVs whose UI layer runs at 1080p. Maybe more efficient, but some features are not supported, e.g. HDR tone mapping and frame readback (snapshot), and fewer codecs.
 ///
 /// 'subtitleFontFile': default subtitle font file as the fallback, can be an http url. If not set, 'assets/subfont.ttf' will be used, you can add it in pubspec.yaml if you need it.
 /// subfont.ttf can be downloaded from https://github.com/mpv-android/mpv-android/raw/master/app/src/main/assets/subfont.ttf

--- a/lib/fvp.dart
+++ b/lib/fvp.dart
@@ -29,6 +29,8 @@ export 'src/controller.dart';
 ///
 /// "tunnel": android only, default is false. AMediacodec/MediaCodec decoder output to a SurfaceTexture surface directly without OpenGL. Maybe more efficient, but some features are not supported, e.g. HDR tone mapping, less codecs.
 ///
+/// "directSurface": android only, default is false, requires VideoViewType.platformView. MediaCodec renders into the SurfaceView's surface itself: no GL renderer, no EGLConfig, no GPU copy, and the video scans out at its native resolution ("maxWidth"/"maxHeight" are not applied). This is what lets a 4K video present at full panel resolution on TVs whose UI layer runs at 1080p. Same trade-offs as "tunnel": no HDR tone mapping and no frame readback (snapshot).
+///
 /// 'subtitleFontFile': default subtitle font file as the fallback, can be an http url. If not set, 'assets/subfont.ttf' will be used, you can add it in pubspec.yaml if you need it.
 /// subfont.ttf can be downloaded from https://github.com/mpv-android/mpv-android/raw/master/app/src/main/assets/subfont.ttf
 ///

--- a/lib/src/video_player_mdk.dart
+++ b/lib/src/video_player_mdk.dart
@@ -272,23 +272,19 @@ class MdkVideoPlayerPlatform extends VideoPlayerPlatform {
   /// (SurfaceView on Android), keyed by playerId. Absent for texture players.
   final _platformViewParams = <int, Map<String, Object>>{};
 
-  /// View type requested by the current createWithOptions() call.
-  VideoViewType _createViewType = VideoViewType.textureView;
-
   @override
-  Future<int?> createWithOptions(VideoCreationOptions options) async {
+  Future<int?> createWithOptions(VideoCreationOptions options) {
     // SurfaceView output is Android-only; other platforms keep the texture.
-    _createViewType =
-        Platform.isAndroid ? options.viewType : VideoViewType.textureView;
-    try {
-      return await create(options.dataSource);
-    } finally {
-      _createViewType = VideoViewType.textureView;
-    }
+    return _create(
+        options.dataSource,
+        Platform.isAndroid ? options.viewType : VideoViewType.textureView);
   }
 
   @override
-  Future<int?> create(DataSource dataSource) async {
+  Future<int?> create(DataSource dataSource) =>
+      _create(dataSource, VideoViewType.textureView);
+
+  Future<int?> _create(DataSource dataSource, VideoViewType viewType) async {
     final uri = _toUri(dataSource);
     final player = MdkVideoPlayer();
     _log.fine('$hashCode player${player.nativeHandle} create($uri)');
@@ -345,14 +341,14 @@ class MdkVideoPlayerPlatform extends VideoPlayerPlatform {
       //player.dispose(); // dispose for throw
       return -hashCode;
     }
-    if (_createViewType == VideoViewType.platformView) {
+    if (viewType == VideoViewType.platformView) {
       // SurfaceView output (Android): no Flutter texture. The surface is
       // created by the FvpVideoView platform view and attached to the player
       // natively; buffers are sized to the video so TVs with an upscaled UI
       // layer (e.g. 1080p UI on a 4K panel) still scan out at full video
       // resolution. playerId is the native handle instead of a texture id.
       final size = await player.textureSize;
-      if (size == null) {
+      if (size == null || size.width <= 0 || size.height <= 0) {
         _players[-hashCode] = player;
         player.streamCtl.addError(PlatformException(
           code: 'video size error',

--- a/lib/src/video_player_mdk.dart
+++ b/lib/src/video_player_mdk.dart
@@ -4,6 +4,9 @@
 
 import 'dart:async';
 import 'dart:io';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/rendering.dart' show PlatformViewHitTestBehavior;
 import 'package:flutter/widgets.dart'; //
 import 'package:flutter/services.dart';
 import 'package:video_player_platform_interface/video_player_platform_interface.dart';
@@ -261,7 +264,27 @@ class MdkVideoPlayerPlatform extends VideoPlayerPlatform {
 
   @override
   Future<void> dispose(int playerId) async {
+    _platformViewParams.remove(playerId);
     _players.remove(playerId)?.dispose();
+  }
+
+  /// Creation parameters for players rendering into a platform view
+  /// (SurfaceView on Android), keyed by playerId. Absent for texture players.
+  final _platformViewParams = <int, Map<String, Object>>{};
+
+  /// View type requested by the current createWithOptions() call.
+  VideoViewType _createViewType = VideoViewType.textureView;
+
+  @override
+  Future<int?> createWithOptions(VideoCreationOptions options) async {
+    // SurfaceView output is Android-only; other platforms keep the texture.
+    _createViewType =
+        Platform.isAndroid ? options.viewType : VideoViewType.textureView;
+    try {
+      return await create(options.dataSource);
+    } finally {
+      _createViewType = VideoViewType.textureView;
+    }
   }
 
   @override
@@ -321,6 +344,61 @@ class MdkVideoPlayerPlatform extends VideoPlayerPlatform {
       ));
       //player.dispose(); // dispose for throw
       return -hashCode;
+    }
+    if (_createViewType == VideoViewType.platformView) {
+      // SurfaceView output (Android): no Flutter texture. The surface is
+      // created by the FvpVideoView platform view and attached to the player
+      // natively; buffers are sized to the video so TVs with an upscaled UI
+      // layer (e.g. 1080p UI on a 4K panel) still scan out at full video
+      // resolution. playerId is the native handle instead of a texture id.
+      final size = await player.textureSize;
+      if (size == null) {
+        _players[-hashCode] = player;
+        player.streamCtl.addError(PlatformException(
+          code: 'video size error',
+          message: 'invalid or unsupported media with invalid video size',
+        ));
+        return -hashCode;
+      }
+      final id = player.nativeHandle;
+      // Respect the same registerWith() "maxWidth"/"maxHeight" options as the
+      // texture path: surface buffers are sized to the video, optionally
+      // clamped. A clamp matters on weak GPUs — GL-rendering full 4K RGBA can
+      // force SurfaceFlinger into GPU composition at panel resolution.
+      var w = size.width.toInt();
+      var h = size.height.toInt();
+      if (_maxWidth != null && _maxHeight != null && (_fitMaxSize ?? true)) {
+        final r = w / h;
+        final fitW = (_maxHeight! * r).toInt();
+        if (fitW <= _maxWidth!) {
+          if (fitW < w) {
+            w = fitW;
+            h = _maxHeight!;
+          }
+        } else if (_maxWidth! < w) {
+          h = (_maxWidth! / r).toInt();
+          w = _maxWidth!;
+        }
+      } else {
+        if (_maxWidth != null && _maxWidth! < w) {
+          h = (h * _maxWidth! / w).round();
+          w = _maxWidth!;
+        }
+        if (_maxHeight != null && _maxHeight! < h) {
+          w = (w * _maxHeight! / h).round();
+          h = _maxHeight!;
+        }
+      }
+      _platformViewParams[id] = <String, Object>{
+        'player': player.nativeHandle,
+        'width': w,
+        'height': h,
+        'tunnel': _tunnel ?? false,
+      };
+      _log.fine('$hashCode player${player.nativeHandle} platform view, '
+          'video ${size.width.toInt()}x${size.height.toInt()}');
+      _players[id] = player;
+      return id;
     }
 // FIXME: pending events will be processed after texture returned, but no events before prepared
 // FIXME: set tunnel too late
@@ -406,6 +484,42 @@ class MdkVideoPlayerPlatform extends VideoPlayerPlatform {
   @override
   Widget buildView(int playerId) {
     return Texture(textureId: playerId);
+  }
+
+  @override
+  Widget buildViewWithOptions(VideoViewOptions options) {
+    final playerId = options.playerId;
+    final creationParams = _platformViewParams[playerId];
+    if (creationParams == null) {
+      // Texture player (default).
+      return buildView(playerId);
+    }
+    // SurfaceView requires hybrid composition (initExpensiveAndroidView):
+    // under Flutter's default TLHC mode a SurfaceView draws at the wrong
+    // location/z-index (see Flutter's Android platform views docs).
+    return PlatformViewLink(
+      viewType: 'fvp/video-view',
+      surfaceFactory: (context, controller) {
+        return AndroidViewSurface(
+          controller: controller as AndroidViewController,
+          gestureRecognizers: const <Factory<OneSequenceGestureRecognizer>>{},
+          hitTestBehavior: PlatformViewHitTestBehavior.transparent,
+        );
+      },
+      onCreatePlatformView: (params) {
+        final controller = PlatformViewsService.initExpensiveAndroidView(
+          id: params.id,
+          viewType: 'fvp/video-view',
+          layoutDirection: TextDirection.ltr,
+          creationParams: creationParams,
+          creationParamsCodec: const StandardMessageCodec(),
+        );
+        controller
+            .addOnPlatformViewCreatedListener(params.onPlatformViewCreated);
+        controller.create();
+        return controller;
+      },
+    );
   }
 
   @override

--- a/lib/src/video_player_mdk.dart
+++ b/lib/src/video_player_mdk.dart
@@ -118,6 +118,7 @@ class MdkVideoPlayerPlatform extends VideoPlayerPlatform {
   static int? _maxHeight;
   static bool? _fitMaxSize;
   static bool? _tunnel;
+  static bool? _directSurface;
   static String? _subtitleFontFile;
   static int _lowLatency = 0;
   static int _seekFlags = mdk.SeekFlag.fromStart | mdk.SeekFlag.inCache;
@@ -158,6 +159,7 @@ class MdkVideoPlayerPlatform extends VideoPlayerPlatform {
       _maxHeight = options["maxHeight"];
       _fitMaxSize = options["fitMaxSize"];
       _tunnel = options["tunnel"];
+      _directSurface = options["directSurface"];
       _playerOpts = options['player'];
       _globalOpts = options['global'];
       // TODO: _env => putenv
@@ -360,10 +362,16 @@ class MdkVideoPlayerPlatform extends VideoPlayerPlatform {
       // Respect the same registerWith() "maxWidth"/"maxHeight" options as the
       // texture path: surface buffers are sized to the video, optionally
       // clamped. A clamp matters on weak GPUs — GL-rendering full 4K RGBA can
-      // force SurfaceFlinger into GPU composition at panel resolution.
+      // force SurfaceFlinger into GPU composition at panel resolution. With
+      // "directSurface" there is no GL renderer at all: MediaCodec owns the
+      // buffer geometry, so the clamp does not apply and the video scans out
+      // at its native resolution.
+      final directSurface = _directSurface ?? false;
       var w = size.width.toInt();
       var h = size.height.toInt();
-      if (_maxWidth != null && _maxHeight != null && (_fitMaxSize ?? true)) {
+      if (directSurface) {
+        // native size, no clamp
+      } else if (_maxWidth != null && _maxHeight != null && (_fitMaxSize ?? true)) {
         final r = w / h;
         final fitW = (_maxHeight! * r).toInt();
         if (fitW <= _maxWidth!) {
@@ -390,6 +398,7 @@ class MdkVideoPlayerPlatform extends VideoPlayerPlatform {
         'width': w,
         'height': h,
         'tunnel': _tunnel ?? false,
+        'direct': directSurface,
       };
       _log.fine('$hashCode player${player.nativeHandle} platform view, '
           'video ${size.width.toInt()}x${size.height.toInt()}');

--- a/lib/src/video_player_mdk.dart
+++ b/lib/src/video_player_mdk.dart
@@ -364,10 +364,9 @@ class MdkVideoPlayerPlatform extends VideoPlayerPlatform {
       // "tunnel" there is no GL renderer at all: MediaCodec owns the buffer
       // geometry, so the clamp does not apply and the video scans out at its
       // native resolution.
-      final directSurface = _tunnel ?? false;
       var w = size.width.toInt();
       var h = size.height.toInt();
-      if (directSurface) {
+      if (_tunnel ?? false) {
         // native size, no clamp
       } else if (_maxWidth != null && _maxHeight != null && (_fitMaxSize ?? true)) {
         final r = w / h;

--- a/lib/src/video_player_mdk.dart
+++ b/lib/src/video_player_mdk.dart
@@ -118,7 +118,6 @@ class MdkVideoPlayerPlatform extends VideoPlayerPlatform {
   static int? _maxHeight;
   static bool? _fitMaxSize;
   static bool? _tunnel;
-  static bool? _directSurface;
   static String? _subtitleFontFile;
   static int _lowLatency = 0;
   static int _seekFlags = mdk.SeekFlag.fromStart | mdk.SeekFlag.inCache;
@@ -159,7 +158,6 @@ class MdkVideoPlayerPlatform extends VideoPlayerPlatform {
       _maxHeight = options["maxHeight"];
       _fitMaxSize = options["fitMaxSize"];
       _tunnel = options["tunnel"];
-      _directSurface = options["directSurface"];
       _playerOpts = options['player'];
       _globalOpts = options['global'];
       // TODO: _env => putenv
@@ -363,10 +361,10 @@ class MdkVideoPlayerPlatform extends VideoPlayerPlatform {
       // texture path: surface buffers are sized to the video, optionally
       // clamped. A clamp matters on weak GPUs — GL-rendering full 4K RGBA can
       // force SurfaceFlinger into GPU composition at panel resolution. With
-      // "directSurface" there is no GL renderer at all: MediaCodec owns the
-      // buffer geometry, so the clamp does not apply and the video scans out
-      // at its native resolution.
-      final directSurface = _directSurface ?? false;
+      // "tunnel" there is no GL renderer at all: MediaCodec owns the buffer
+      // geometry, so the clamp does not apply and the video scans out at its
+      // native resolution.
+      final directSurface = _tunnel ?? false;
       var w = size.width.toInt();
       var h = size.height.toInt();
       if (directSurface) {
@@ -398,7 +396,6 @@ class MdkVideoPlayerPlatform extends VideoPlayerPlatform {
         'width': w,
         'height': h,
         'tunnel': _tunnel ?? false,
-        'direct': directSurface,
       };
       _log.fine('$hashCode player${player.nativeHandle} platform view, '
           'video ${size.width.toInt()}x${size.height.toInt()}');

--- a/lib/src/video_player_mdk.dart
+++ b/lib/src/video_player_mdk.dart
@@ -511,7 +511,9 @@ class MdkVideoPlayerPlatform extends VideoPlayerPlatform {
         final controller = PlatformViewsService.initExpensiveAndroidView(
           id: params.id,
           viewType: 'fvp/video-view',
-          layoutDirection: TextDirection.ltr,
+          // The direction Flutter resolved for this view's context — a
+          // hard-coded ltr lays the view out wrongly in an RTL app.
+          layoutDirection: params.layoutDirection,
           creationParams: creationParams,
           creationParamsCodec: const StandardMessageCodec(),
         );

--- a/lib/src/video_player_mdk.dart
+++ b/lib/src/video_player_mdk.dart
@@ -275,8 +275,7 @@ class MdkVideoPlayerPlatform extends VideoPlayerPlatform {
   @override
   Future<int?> createWithOptions(VideoCreationOptions options) {
     // SurfaceView output is Android-only; other platforms keep the texture.
-    return _create(
-        options.dataSource,
+    return _create(options.dataSource,
         Platform.isAndroid ? options.viewType : VideoViewType.textureView);
   }
 
@@ -368,7 +367,9 @@ class MdkVideoPlayerPlatform extends VideoPlayerPlatform {
       var h = size.height.toInt();
       if (_tunnel ?? false) {
         // native size, no clamp
-      } else if (_maxWidth != null && _maxHeight != null && (_fitMaxSize ?? true)) {
+      } else if (_maxWidth != null &&
+          _maxHeight != null &&
+          (_fitMaxSize ?? true)) {
         final r = w / h;
         final fitW = (_maxHeight! * r).toInt();
         if (fitW <= _maxWidth!) {
@@ -498,31 +499,39 @@ class MdkVideoPlayerPlatform extends VideoPlayerPlatform {
     // SurfaceView requires hybrid composition (initExpensiveAndroidView):
     // under Flutter's default TLHC mode a SurfaceView draws at the wrong
     // location/z-index (see Flutter's Android platform views docs).
-    return PlatformViewLink(
-      viewType: 'fvp/video-view',
-      surfaceFactory: (context, controller) {
-        return AndroidViewSurface(
-          controller: controller as AndroidViewController,
-          gestureRecognizers: const <Factory<OneSequenceGestureRecognizer>>{},
-          hitTestBehavior: PlatformViewHitTestBehavior.transparent,
-        );
-      },
-      onCreatePlatformView: (params) {
-        final controller = PlatformViewsService.initExpensiveAndroidView(
-          id: params.id,
-          viewType: 'fvp/video-view',
-          // The direction Flutter resolved for this view's context — a
-          // hard-coded ltr lays the view out wrongly in an RTL app.
-          layoutDirection: params.layoutDirection,
-          creationParams: creationParams,
-          creationParamsCodec: const StandardMessageCodec(),
-        );
-        controller
-            .addOnPlatformViewCreatedListener(params.onPlatformViewCreated);
-        controller.create();
-        return controller;
-      },
-    );
+    //
+    // Builder: the view has to be laid out in the direction that applies where
+    // it is mounted, and that is only readable from a context below this
+    // widget (PlatformViewCreationParams does not carry it).
+    return Builder(builder: (context) {
+      final layoutDirection =
+          Directionality.maybeOf(context) ?? TextDirection.ltr;
+      return PlatformViewLink(
+        viewType: 'fvp/video-view',
+        surfaceFactory: (context, controller) {
+          return AndroidViewSurface(
+            controller: controller as AndroidViewController,
+            gestureRecognizers: const <Factory<OneSequenceGestureRecognizer>>{},
+            hitTestBehavior: PlatformViewHitTestBehavior.transparent,
+          );
+        },
+        onCreatePlatformView: (params) {
+          final controller = PlatformViewsService.initExpensiveAndroidView(
+            id: params.id,
+            viewType: 'fvp/video-view',
+            // The direction Flutter resolved for this view's context — a
+            // hard-coded ltr lays the view out wrongly in an RTL app.
+            layoutDirection: layoutDirection,
+            creationParams: creationParams,
+            creationParamsCodec: const StandardMessageCodec(),
+          );
+          controller
+              .addOnPlatformViewCreatedListener(params.onPlatformViewCreated);
+          controller.create();
+          return controller;
+        },
+      );
+    });
   }
 
   @override

--- a/lib/src/video_player_mdk.dart
+++ b/lib/src/video_player_mdk.dart
@@ -356,13 +356,9 @@ class MdkVideoPlayerPlatform extends VideoPlayerPlatform {
         return -hashCode;
       }
       final id = player.nativeHandle;
-      // Respect the same registerWith() "maxWidth"/"maxHeight" options as the
-      // texture path: surface buffers are sized to the video, optionally
-      // clamped. A clamp matters on weak GPUs — GL-rendering full 4K RGBA can
-      // force SurfaceFlinger into GPU composition at panel resolution. With
-      // "tunnel" there is no GL renderer at all: MediaCodec owns the buffer
-      // geometry, so the clamp does not apply and the video scans out at its
-      // native resolution.
+      // Clamp the GL render target as the texture path does — full 4K RGBA can
+      // push SurfaceFlinger into GPU composition on weak GPUs. "tunnel" has no
+      // GL renderer, so the decoder's own geometry stands.
       var w = size.width.toInt();
       var h = size.height.toInt();
       if (_tunnel ?? false) {
@@ -499,10 +495,7 @@ class MdkVideoPlayerPlatform extends VideoPlayerPlatform {
     // SurfaceView requires hybrid composition (initExpensiveAndroidView):
     // under Flutter's default TLHC mode a SurfaceView draws at the wrong
     // location/z-index (see Flutter's Android platform views docs).
-    //
-    // Builder: the view has to be laid out in the direction that applies where
-    // it is mounted, and that is only readable from a context below this
-    // widget (PlatformViewCreationParams does not carry it).
+    // Builder: Directionality is only readable from a context below this.
     return Builder(builder: (context) {
       final layoutDirection =
           Directionality.maybeOf(context) ?? TextDirection.ltr;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,9 @@ dependencies: # TODO: limit max version?
   path: any
   plugin_platform_interface: any
   video_player: any
-  video_player_platform_interface: any
+  # 6.3.0 is where VideoViewType/createWithOptions/buildViewWithOptions land,
+  # which the Android platform view path needs.
+  video_player_platform_interface: '>=6.3.0'
   path_provider: any
   http: any
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,8 +10,8 @@ topics:
   - elinux
 
 environment:
-  sdk: ^3.0.0
-  flutter: ">=3.0.0"
+  sdk: ^3.4.0
+  flutter: ">=3.22.0"
 
 dependencies: # TODO: limit max version?
   ffi: any


### PR DESCRIPTION
Implements the video_player platform interface's `VideoViewType.platformView` on Android with a SurfaceView-backed platform view (`fvp/video-view`), registered via hybrid composition (Flutter's default TLHC mode cannot host a SurfaceView — it draws at the wrong location/z-index).

## Why

Android TVs commonly run the UI layer below panel resolution (e.g. 1080p UI on a 4K panel — see [media3 "Surface types"](https://developer.android.com/media/media3/ui/surface): "SurfaceView must be used to render content at the full resolution of the display" on such devices). The Texture path is capped at UI resolution and costs an extra compositor pass in the Flutter engine.

Measured on the TCL/RTD2875P device from #374 (SurfaceFlinger presentation timestamps, 127-frame windows, 4K HEVC 24 fps source, hardware decode, buffers capped to 1920 via `maxWidth`):

| Path | Presented fps | Frames >55 ms late |
|---|---|---|
| Texture (`buildView`) | 10.9 | ~half |
| **SurfaceView platform view (this PR)** | **21.5** | **0** |

A SurfaceView is also the only surface type that can display tunneled playback, so this is a prerequisite for tunnel working at all with Flutter.

## How

- `FvpVideoView` (Java): SurfaceView whose surface is handed to the player through the existing `nativeSetSurface` JNI; negative synthetic ids so TextureRegistry ids can never collide. Buffers are `setFixedSize`d to the video resolution, clamped by the existing `maxWidth`/`maxHeight` registerWith options (matters on weak TV GPUs: uncapped 4K RGBA forces SurfaceFlinger into GPU composition at panel resolution — measured 5.5 fps).
- Dart: `createWithOptions` honors `options.viewType` (platform view players skip texture creation; playerId = native handle), `buildViewWithOptions` returns a `PlatformViewLink` using `initExpensiveAndroidView`.
- `nativeSetSurface` becomes `static` (same JNI symbol/ABI) so the view can call it.

## Known limitation — tunnel still fails, needs libmdk support

Platform-view surfaces are created after `prepare()`, when the video decoder has already opened without a tunnel surface (your existing `FIXME: set tunnel too late`). This PR re-sets the video decoder list on late tunnel-surface arrival to force a decoder re-open with the surface property present — but MDK still opens the codec with:

```
tunnel: 0, window: 0xbdf04ba8/0, surface: 0x0/9946, image: 1
```

i.e. `video.decoder = surface=<jobject>` set before (re-)open does not get wired into a tunneled MediaCodec config (Realtek RTD2875P, Android 12; full logcat in the follow-up comment). With that working, this TV should reach native 4K with zero GPU involvement. Happy to test libmdk changes on this device.

Tested on TCL Google TV (RTD2875P / PowerVR BXE-4-32, Android 12, Flutter 3.44.2) and desktop (texture path unchanged).

