### PR TITLE
expose audioBackends option in registerWith

### DIFF
--- a/lib/fvp.dart
+++ b/lib/fvp.dart
@@ -19,6 +19,8 @@ export 'src/controller.dart';
 ///
 /// "video.decoders": a list of decoder names. supported decoders: https://github.com/wang-bin/mdk-sdk/wiki/Decoders
 ///
+/// "audioBackends": a list of audio renderer names passed to Player.setAudioBackends, e.g. ['AudioTrack'] or ['OpenSL'] on android. If not set, mdk's default order is used.
+///
 /// "maxWidth", "maxHeight": texture max size. if not set, video frame size is used. a small value can reduce memory cost, but may result in lower image quality.
 ///
 /// 'lowLatency': int. default is 0. reduce network stream latency. 1: for vod. 2: for live stream, may drop frames to ensure the latest content is displayed

--- a/lib/src/video_player_mdk.dart
+++ b/lib/src/video_player_mdk.dart
@@ -119,6 +119,7 @@ class MdkVideoPlayerPlatform extends VideoPlayerPlatform {
   static int _lowLatency = 0;
   static int _seekFlags = mdk.SeekFlag.fromStart | mdk.SeekFlag.inCache;
   static List<String>? _decoders;
+  static List<String>? _audioBackends;
   static final _mdkLog = Logger('mdk');
   // _prevImpl: required if registerWith() can be invoked multiple times by user
   static VideoPlayerPlatform? _prevImpl;
@@ -159,6 +160,7 @@ class MdkVideoPlayerPlatform extends VideoPlayerPlatform {
       _globalOpts = options['global'];
       // TODO: _env => putenv
       _decoders = options['video.decoders'];
+      _audioBackends = options['audioBackends'];
       _subtitleFontFile = options['subtitleFontFile'];
     }
 
@@ -290,6 +292,9 @@ class MdkVideoPlayerPlatform extends VideoPlayerPlatform {
 
     if (_decoders != null) {
       player.videoDecoders = _decoders!;
+    }
+    if (_audioBackends != null) {
+      player.audioBackends = _audioBackends!;
     }
     if (_lowLatency > 0) {
 // +nobuffer: the 1st key-frame packet is dropped. -nobuffer: high latency

--- a/lib/src/video_player_mdk.dart
+++ b/lib/src/video_player_mdk.dart
@@ -160,7 +160,7 @@ class MdkVideoPlayerPlatform extends VideoPlayerPlatform {
       _globalOpts = options['global'];
       // TODO: _env => putenv
       _decoders = options['video.decoders'];
-      _audioBackends = options['audioBackends'];
+      _audioBackends = (options['audioBackends'] as List?)?.cast<String>();
       _subtitleFontFile = options['subtitleFontFile'];
     }
 


### PR DESCRIPTION
adds an `audioBackends` key to registerWith options, passed to `Player.setAudioBackends` (same pattern as `video.decoders`):

```dart
registerWith(options: {'audioBackends': ['OpenSL']});
```

why: on my android tv (TCL google tv, realtek RTD2875P, android 12) the default AAudio backend reports playback positions so coarsely that avsync bursts video frames chasing it — 10.10 presented fps with 424 gaps ≥80ms in 60s on a 24fps clip. with OpenSL the same clip is frame-perfect: 24.21 fps, 0 gaps ≥80ms, matching libmpv on the same device. full measurements in the linked issue.

tested on device with all three android backends (AAudio / AudioTrack / OpenSL).

(developed with an AI assistant (Fable), tested and verified on device)